### PR TITLE
Fix python code - support malformed ID3 tags, support unicode filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /K0*/
 .idea
 *.class
+__pycache__/

--- a/python/redele.py
+++ b/python/redele.py
@@ -2,28 +2,16 @@
 # -*- coding: utf-8 -*-
 
 import codecs
+import mutagen
 import os
 import sys
 import re
 import shutil
+import utils
 
 from gooey import GooeyParser
 from mutagen.id3 import ID3, TIT2
 from mutagen.mp3 import MP3
-
-# Support for monkey-patching mutagen's ID3Header constructor below - includes
-# from mutagen/id3/_tags.py copied verbatim - maybe some are not needed...
-import mutagen
-import struct
-from itertools import zip_longest
-from mutagen._tags import Tags
-from mutagen._util import DictProxy, convert_error, read_full
-from mutagen.id3._util import BitPaddedInt, unsynch, ID3JunkFrameError, \
-    ID3EncryptionUnsupportedError, is_valid_frame_id, error, \
-    ID3NoHeaderError, ID3UnsupportedVersionError, ID3SaveConfig
-from mutagen.id3._frames import TDRC, APIC, TDOR, TIME, TIPL, TORY, TDAT, Frames_2_2, \
-    TextFrame, TYER, Frame, IPLS, Frames
-# support for monkeypatching ends
 
 
 
@@ -49,83 +37,6 @@ byte_low_nibble_odd = [[0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF],
                        [0x1, 0x0, 0x3, 0x2, 0x5, 0x4, 0x7, 0x6],
                        [0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF]]
 
-# Constructor of mutagen's class mutagen.id3._tags.ID3Header needs to be monkeypatched.
-# Out of the box it raises exception when trying to delete ID3 tags where header size
-# is not synchsafe (e.g. indicating that the chunk is playable MP3 stream part).
-# Since we're only trying to get rid of all ID3 tags, we don't worry about their quality...
-@convert_error(IOError, error)
-def id3header_constructor_monkeypatch(self, fileobj=None):
-    """Raises ID3NoHeaderError, ID3UnsupportedVersionError or error"""
-
-    if fileobj is None:
-        # for testing
-        self._flags = 0
-        return
-
-    fn = getattr(fileobj, "name", "<unknown>")
-    data = fileobj.read(10)
-    if len(data) != 10:
-        raise ID3NoHeaderError("%s: too small" % fn)
-
-    id3, vmaj, vrev, flags, size = struct.unpack('>3sBBB4s', data)
-    self._flags = flags
-    self.size = BitPaddedInt(size) + 10
-    self.version = (2, vmaj, vrev)
-
-    if id3 != b'ID3':
-        raise ID3NoHeaderError("%r doesn't start with an ID3 tag" % fn)
-
-    if vmaj not in [2, 3, 4]:
-        raise ID3UnsupportedVersionError("%r ID3v2.%d not supported"
-                                         % (fn, vmaj))
-
-    # Monkeypatch root cause - we need to be able to delete even incorrect ID3 tags...
-    #if not BitPaddedInt.has_valid_padding(size):
-    #    raise error("Header size not synchsafe")
-
-    if (self.version >= self._V24) and (flags & 0x0f):
-        raise error(
-            "%r has invalid flags %#02x" % (fn, flags))
-    elif (self._V23 <= self.version < self._V24) and (flags & 0x1f):
-        raise error(
-            "%r has invalid flags %#02x" % (fn, flags))
-
-    if self.f_extended:
-        extsize_data = read_full(fileobj, 4)
-
-        frame_id = extsize_data.decode("ascii", "replace")
-
-        if frame_id in Frames:
-            # Some tagger sets the extended header flag but
-            # doesn't write an extended header; in this case, the
-            # ID3 data follows immediately. Since no extended
-            # header is going to be long enough to actually match
-            # a frame, and if it's *not* a frame we're going to be
-            # completely lost anyway, this seems to be the most
-            # correct check.
-            # https://github.com/quodlibet/quodlibet/issues/126
-            self._flags ^= 0x40
-            extsize = 0
-            fileobj.seek(-4, 1)
-        elif self.version >= self._V24:
-            # "Where the 'Extended header size' is the size of the whole
-            # extended header, stored as a 32 bit synchsafe integer."
-            extsize = BitPaddedInt(extsize_data) - 4
-            # Haven't seen any MP3s broken in this way, but safe to say we
-            # should be able to remove ID3s on them too :-)
-            # Monkey-patched out
-            #if not BitPaddedInt.has_valid_padding(extsize_data):
-            #    raise error(
-            #        "Extended header size not synchsafe")
-        else:
-            # "Where the 'Extended header size', currently 6 or 10 bytes,
-            # excludes itself."
-            extsize = struct.unpack('>L', extsize_data)[0]
-
-        if extsize < 0:
-            raise error("invalid extended header size")
-
-        self._extdata = read_full(fileobj, extsize)
 
 def clear_and_set_title(mp3_file, new_title):
     """ Remove all MP3 tags and set a single title tag """
@@ -245,9 +156,9 @@ def main():
     args = parser.parse_args()
     
     if sys.stdout.encoding != 'UTF-8':
-        sys.stdout = codecs.getwriter('utf-8')(sys.stdout.buffer, 'strict')
+        sys.stdout = utils.Unbuffered(codecs.getwriter('utf-8')(sys.stdout.buffer, 'strict'))
     if sys.stderr.encoding != 'UTF-8':
-        sys.stderr = codecs.getwriter('utf-8')(sys.stderr.buffer, 'strict')    
+        sys.stderr = utils.Unbuffered(codecs.getwriter('utf-8')(sys.stderr.buffer, 'strict'))    
 
     if not os.path.isdir(args.source_folder):
         print(f"Error: Source folder '{args.source_folder}' does not exist or is not a directory.")
@@ -257,7 +168,7 @@ def main():
         
         # monkeypatch out exceptions on invalid ID3 headers - we're only trying to delete
         # every ID3 tag after all...
-        mutagen.id3._tags.ID3Header.__init__ = id3header_constructor_monkeypatch
+        mutagen.id3._tags.ID3Header.__init__ = utils.id3header_constructor_monkeypatch
         
         if not re.match(r"^\d{3}$", args.figure_id):
             print("Error: Figure ID must be exactly 3 digits.")

--- a/python/utils.py
+++ b/python/utils.py
@@ -1,0 +1,104 @@
+# Support for monkey-patching mutagen's ID3Header constructor below - includes
+# from mutagen/id3/_tags.py copied verbatim - maybe some are not needed...
+import struct
+from itertools import zip_longest
+from mutagen._tags import Tags
+from mutagen._util import DictProxy, convert_error, read_full
+from mutagen.id3._util import BitPaddedInt, unsynch, ID3JunkFrameError, \
+    ID3EncryptionUnsupportedError, is_valid_frame_id, error, \
+    ID3NoHeaderError, ID3UnsupportedVersionError, ID3SaveConfig
+from mutagen.id3._frames import TDRC, APIC, TDOR, TIME, TIPL, TORY, TDAT, Frames_2_2, \
+    TextFrame, TYER, Frame, IPLS, Frames
+# support for monkeypatching ends
+
+
+
+# Constructor of mutagen's class mutagen.id3._tags.ID3Header needs to be monkeypatched.
+# Out of the box it raises exception when trying to delete ID3 tags where header size
+# is not synchsafe (e.g. indicating that the chunk is playable MP3 stream part).
+# Since we're only trying to get rid of all ID3 tags, we don't worry about their quality...
+@convert_error(IOError, error)
+def id3header_constructor_monkeypatch(self, fileobj=None):
+    """Raises ID3NoHeaderError, ID3UnsupportedVersionError or error"""
+
+    if fileobj is None:
+        # for testing
+        self._flags = 0
+        return
+
+    fn = getattr(fileobj, "name", "<unknown>")
+    data = fileobj.read(10)
+    if len(data) != 10:
+        raise ID3NoHeaderError("%s: too small" % fn)
+
+    id3, vmaj, vrev, flags, size = struct.unpack('>3sBBB4s', data)
+    self._flags = flags
+    self.size = BitPaddedInt(size) + 10
+    self.version = (2, vmaj, vrev)
+
+    if id3 != b'ID3':
+        raise ID3NoHeaderError("%r doesn't start with an ID3 tag" % fn)
+
+    if vmaj not in [2, 3, 4]:
+        raise ID3UnsupportedVersionError("%r ID3v2.%d not supported"
+                                         % (fn, vmaj))
+
+    # Monkeypatch root cause - we need to be able to delete even incorrect ID3 tags...
+    #if not BitPaddedInt.has_valid_padding(size):
+    #    raise error("Header size not synchsafe")
+
+    if (self.version >= self._V24) and (flags & 0x0f):
+        raise error(
+            "%r has invalid flags %#02x" % (fn, flags))
+    elif (self._V23 <= self.version < self._V24) and (flags & 0x1f):
+        raise error(
+            "%r has invalid flags %#02x" % (fn, flags))
+
+    if self.f_extended:
+        extsize_data = read_full(fileobj, 4)
+
+        frame_id = extsize_data.decode("ascii", "replace")
+
+        if frame_id in Frames:
+            # Some tagger sets the extended header flag but
+            # doesn't write an extended header; in this case, the
+            # ID3 data follows immediately. Since no extended
+            # header is going to be long enough to actually match
+            # a frame, and if it's *not* a frame we're going to be
+            # completely lost anyway, this seems to be the most
+            # correct check.
+            # https://github.com/quodlibet/quodlibet/issues/126
+            self._flags ^= 0x40
+            extsize = 0
+            fileobj.seek(-4, 1)
+        elif self.version >= self._V24:
+            # "Where the 'Extended header size' is the size of the whole
+            # extended header, stored as a 32 bit synchsafe integer."
+            extsize = BitPaddedInt(extsize_data) - 4
+            # Haven't seen any MP3s broken in this way, but safe to say we
+            # should be able to remove ID3s on them too :-)
+            # Monkey-patched out
+            #if not BitPaddedInt.has_valid_padding(extsize_data):
+            #    raise error(
+            #        "Extended header size not synchsafe")
+        else:
+            # "Where the 'Extended header size', currently 6 or 10 bytes,
+            # excludes itself."
+            extsize = struct.unpack('>L', extsize_data)[0]
+
+        if extsize < 0:
+            raise error("invalid extended header size")
+
+        self._extdata = read_full(fileobj, extsize)
+
+class Unbuffered(object):
+   def __init__(self, stream):
+       self.stream = stream
+   def write(self, data):
+       self.stream.write(data)
+       self.stream.flush()
+   def writelines(self, datas):
+       self.stream.writelines(datas)
+       self.stream.flush()
+   def __getattr__(self, attr):
+       return getattr(self.stream, attr)


### PR DESCRIPTION
* Add monkeypatch to enable loading ID3 headers with "not syncsafe" header size
* Add support for filenames not in system default codepage on windows (all string operations are now hardcoded to UTF-8 in all possible places)
