### PR TITLE
Fix bug when MP3 files have missing or minimal tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 *.class
 __pycache__/
+.DS_Store

--- a/createFigure.sh
+++ b/createFigure.sh
@@ -63,8 +63,11 @@ for file in "$SOURCE_FOLDER"/*.mp3; do
 
     # Copy the modified mp3 to the output directory
     cp "$file" "$OUTPUT_DIR/CP${ITERATOR}"
-    # Change title
-    id3v2 -t "$NEW_TITLE" "$OUTPUT_DIR/CP${ITERATOR}"
+
+    # Clear all tags
+    id3v2 -D "$OUTPUT_DIR/CP${ITERATOR}" >/dev/null 2>&1
+    # Add tags needed for Faba
+    id3v2 -A "Album Album" -a "Artist Artist" -T "1/1" -c "Converted for Faba Box" -t "$NEW_TITLE" "$OUTPUT_DIR/CP${ITERATOR}"
     # Cipher the file
     java MKICipher "$OUTPUT_DIR/CP${ITERATOR}"
     # Remove source file


### PR DESCRIPTION
First of all, thank you for this amazing repo! I had a great time with my kid thanks to it 😄
Now it’s time to give something back.

I found a bug that’s easy to reproduce, and I’ve fixed it.

## Steps to reproduce

- Take an MP3 file.
- Remove all tags using the `id3v2 -D ...` command.
- Encrypt it and put it into the Faba Box.
- The Faba Box keeps the red light on, emits a short “pf” sound, and does nothing else.

## Fix

I delete the tags before encrypting, so we start from a clean, consistent state.
Then I add the minimum required metadata. I tested many combinations, and this is the smallest set that works — if I remove anything else, the bug comes back.

I’ve chosen fixed values instead of dynamic ones (for example, the track number is always set to 1) to show that the actual values don’t matter — only that the file contains at least this minimal set of MP3 tags.